### PR TITLE
Base64 encoded cookie might contain equals (=)

### DIFF
--- a/src/main/resources/static/js/delete.js
+++ b/src/main/resources/static/js/delete.js
@@ -29,7 +29,7 @@ $(function() {
     function getCsrfTokenFromCookie() {
         var cookies = {};
         document.cookie.split(';').forEach(function(cookie) {
-            var keyAndValue = cookie.trim().split('=');
+            var keyAndValue = cookie.trim().split(/=(.+)?/);
             cookies[keyAndValue[0]] = keyAndValue[1];
         });
         return cookies['csrfToken'];


### PR DESCRIPTION
- The Javascript is splitting on "=" to fetch the csrfToken from the cookie
- The csrfToken is Base64 encoded, so might contain "=" as a part of it
- So fixing the bug to split on first occurence of "="
