### PR TITLE
Use mavenCentral mirror for a missing dependency for the old mirror

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
     ]
 
     repositories {
-        maven {url 'https://maven-central.storage.googleapis.com'}
+        mavenCentral()
     }
 
     dependencies {
@@ -21,7 +21,7 @@ buildscript {
 }
 
 repositories {
-    maven {url 'https://maven-central.storage.googleapis.com'}
+    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
One of the dependency(org.eclipse.jetty.*) no longer exists in the existing maven mirror used
https://maven-central.storage.googleapis.com


Hence have replaced with mavenCentral()

